### PR TITLE
Remove spaces from Numbers in CreateDatasetUseCase

### DIFF
--- a/app/src/main/java/com/adyen/testcards/domain/CreateDatasetUseCase.kt
+++ b/app/src/main/java/com/adyen/testcards/domain/CreateDatasetUseCase.kt
@@ -24,7 +24,7 @@ internal class CreateDatasetUseCase @Inject constructor() {
         with(parsedStructure) {
             val emptyPresentation = RemoteViews(applicationId, android.R.layout.simple_list_item_1)
             creditCardNumberId?.let {
-                datasetBuilder.setValue(it, AutofillValue.forText(card.number), emptyPresentation)
+                datasetBuilder.setValue(it, AutofillValue.forText(card.number.replaceSpaces()), emptyPresentation)
             }
             creditCardExpiryDateId?.let {
                 datasetBuilder.setValue(
@@ -51,7 +51,7 @@ internal class CreateDatasetUseCase @Inject constructor() {
         with(parsedStructure) {
             val emptyPresentation = RemoteViews(applicationId, android.R.layout.simple_list_item_1)
             giftCardNumberId?.let {
-                datasetBuilder.setValue(it, AutofillValue.forText(card.number), emptyPresentation)
+                datasetBuilder.setValue(it, AutofillValue.forText(card.number.replaceSpaces()), emptyPresentation)
             }
             giftCardPinId?.let {
                 datasetBuilder.setValue(it, AutofillValue.forText(card.securityCode), emptyPresentation)
@@ -67,7 +67,7 @@ internal class CreateDatasetUseCase @Inject constructor() {
         with(parsedStructure) {
             val emptyPresentation = RemoteViews(applicationId, android.R.layout.simple_list_item_1)
             ibanId?.let {
-                datasetBuilder.setValue(it, AutofillValue.forText(iban.iban), emptyPresentation)
+                datasetBuilder.setValue(it, AutofillValue.forText(iban.iban.replaceSpaces()), emptyPresentation)
             }
         }
 
@@ -101,5 +101,9 @@ internal class CreateDatasetUseCase @Inject constructor() {
         }
 
         return datasetBuilder.build()
+    }
+
+    private fun String.replaceSpaces(): String {
+        return this.replace(" ", "")
     }
 }


### PR DESCRIPTION
## Summary
As discussed in #21 this PR allows to paste credit card numbers, ibans etc. to be pasted without spaces in between the different "blocks"
This enables my app to use this test app since it limits the amount of characters being pasted 

## Tested scenarios
Install Test App
Set the Autofill App to the Test App
Open my app (or any app) with an Autofill Field for credit card information
Autofill the Credit Card Field with a random credit card from the test app
See that the number is pasted without spaces into my app

**Fixed issue**:  #21 
