### PR TITLE
Fix Android 10 crash

### DIFF
--- a/app/src/main/java/com/adyen/testcards/autofill/AdyenTestCardsAutofillService.kt
+++ b/app/src/main/java/com/adyen/testcards/autofill/AdyenTestCardsAutofillService.kt
@@ -38,7 +38,11 @@ class AdyenTestCardsAutofillService : AutofillService() {
 
         val responseBuilder = FillResponse.Builder()
 
-        pendingIntent = AutofillActivity.createPendingIntent(this, parsedStructure, requestCode.getAndIncrement())
+        pendingIntent = AutofillActivity.createPendingIntent(
+            context = applicationContext,
+            parsedStructure = parsedStructure,
+            requestCode = requestCode.getAndIncrement(),
+        )
         val remoteViews = RemoteViews(packageName, R.layout.item_autofill_entry)
 
         val datasetBuilder = Dataset.Builder()

--- a/app/src/main/java/com/adyen/testcards/autofill/AutofillActivity.kt
+++ b/app/src/main/java/com/adyen/testcards/autofill/AutofillActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.core.os.bundleOf
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.adyen.testcards.ui.theme.AdyenTheme
@@ -52,7 +53,8 @@ internal class AutofillActivity : ComponentActivity() {
 
     companion object {
 
-        private const val EXTRA_PARSED_RESULT = "EXTRA_PARSED_RESULT"
+        internal const val EXTRA_BUNDLE = "EXTRA_BUNDLE"
+        internal const val EXTRA_PARSED_RESULT = "EXTRA_PARSED_RESULT"
 
         internal fun createPendingIntent(
             context: Context,
@@ -60,7 +62,8 @@ internal class AutofillActivity : ComponentActivity() {
             requestCode: Int,
         ): PendingIntent {
             val intent = Intent(context, AutofillActivity::class.java).apply {
-                putExtra(EXTRA_PARSED_RESULT, parsedStructure)
+                // Wrap parsed structure in a bundle to ensure it's available in extra's on older android versions.
+                putExtra(EXTRA_BUNDLE, bundleOf(EXTRA_PARSED_RESULT to parsedStructure))
             }
 
             val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/adyen/testcards/autofill/AutofillViewModel.kt
+++ b/app/src/main/java/com/adyen/testcards/autofill/AutofillViewModel.kt
@@ -1,5 +1,6 @@
 package com.adyen.testcards.autofill
 
+import android.os.Bundle
 import android.service.autofill.Dataset
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
@@ -34,7 +35,9 @@ internal class AutofillViewModel @Inject constructor(
     private val createDatasetUseCase: CreateDatasetUseCase,
 ) : ViewModel() {
 
-    private val parsedStructure: ParsedStructure = savedStateHandle["EXTRA_PARSED_RESULT"]!!
+    private val parsedStructure: ParsedStructure = savedStateHandle
+        .get<Bundle>(AutofillActivity.EXTRA_BUNDLE)
+        ?.getParcelable(AutofillActivity.EXTRA_PARSED_RESULT)!!
     private val detectedPaymentMethod = detectPaymentMethod()
 
     private val _dataset = MutableSharedFlow<Dataset>()


### PR DESCRIPTION
## Summary
When opening the autofill selection on Android 10 (and possibly other older Android versions) it would crash.

The crash was caused by the parsed structure not being available in the intent extras. Wrapping the parsed structure in a bundle ensures it is always available in the extras on any Android version.
